### PR TITLE
Changes to Sophos EDR integration and VAR Config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,11 +1,9 @@
 ### GENERAL SETUP
 # Vectra brain API access.
-COGNITO_URL = [
-    "",
-]
+COGNITO_URL = [""]
 SLEEP_MINUTES = 5
 # All brains must use the same API version. Run a different instance of this script for each API version
-
+V3 = False
 # Available options: ['bitdefender', 'checkpoint', 'cisco_amp', 'cisco_asa_http', 'cisco_fmc', 'cisco_ise',
 # 'cisco_pxgrid', 'clearpass', 'cortex', 'endgame', 'external_call', 'forti_edr', q'fortinet',
 # 'harmony', 'mcafee_epo', 'meraki', 'pan', 'pulse_nac', 'sophos', 'tanium', 'test_client', 'trendmicro_apexone',

--- a/third_party_clients/sophos_edr/README.md
+++ b/third_party_clients/sophos_edr/README.md
@@ -30,7 +30,7 @@ CHECK_SSL = False
 To utilize this client within the VAR Framework, add `"sophos_edr"` to the list of `THIRD_PARTY_CLIENTS` in [config.py](../../config.py).
 
 # Validation
-- Untested
+Tested in production environment by Telonic GmbH.
 
 # Resources
 - https://developer.sophos.com/docs/endpoint-v1/1/overview

--- a/third_party_clients/sophos_edr/README.md
+++ b/third_party_clients/sophos_edr/README.md
@@ -30,7 +30,7 @@ CHECK_SSL = False
 To utilize this client within the VAR Framework, add `"sophos_edr"` to the list of `THIRD_PARTY_CLIENTS` in [config.py](../../config.py).
 
 # Validation
-Tested in production environment by Telonic GmbH.
+Implemented in production environment by Telonic GmbH.
 
 # Resources
 - https://developer.sophos.com/docs/endpoint-v1/1/overview

--- a/third_party_clients/sophos_edr/sophos_edr.py
+++ b/third_party_clients/sophos_edr/sophos_edr.py
@@ -103,24 +103,14 @@ class Client(ThirdPartyInterface):
             self.logger.error(
                     f"Error searching for {host.ip}: {result.text}"
             )
-        if len(endpoints) != 1:
+        if len(endpoints) < 1:
             self.logger.error(
-                "Found no endpoints or multiple endpoints with same IP. Aborting!"
+                "Found no endpoints. Aborting!"
             )
             return False
         else:
             endpoint = endpoints[0]
-            if not f"{endpoint.get('hostname', 'NOTFOUND')}".lower().startswith(
-                host.name.lower()
-            ):
-                self.logger.error(
-                    f"Endpoint name {endpoint.get('name').lower()} \
-                        does not match Vectra hostname {host.name.lower()}!"
-                )
-                return False
-            else:
-                self.logger.info("Endpoint name matches Vectra host name")
-                return endpoint
+            return endpoint
 
     def block_host(self, host: VectraHost) -> list:
         endpoint = self._list_endpoint(host)
@@ -136,7 +126,7 @@ class Client(ThirdPartyInterface):
                 }
         isolate_url = f"{self.dataRegion}/endpoint/v1/endpoints/isolation"
         try:
-            results = requests.post(isolate_url, headers=self.headers, json_data=body)
+            results = requests.post(isolate_url, headers=self.headers, json=body)
         except Exception as e:
             self.logger.debug(f"SophosEDR isolation failed with status: {e}")
             results = False
@@ -149,7 +139,6 @@ class Client(ThirdPartyInterface):
             return []
 
     def unblock_host(self, host: VectraHost) -> list:
-        return []
         isolate_url = f"{self.dataRegion}/endpoint/v1/endpoints/isolation"
         endpoint_ids = host.blocked_elements.get(self.name, [])
         un_isolated = []
@@ -162,7 +151,7 @@ class Client(ThirdPartyInterface):
                         "comment": "Isolating requested by Vectra integration"
                         }
                 try:
-                    results = requests.post(isolate_url, headers=self.headers, json_data=body)
+                    results = requests.post(isolate_url, headers=self.headers, json=body)
                 except Exception as e:
                     self.logger.debug(f"SophosEDR isolation failed with status: {e}")
                     results = False


### PR DESCRIPTION
Hello Vectra Team,
I would like to request a merge for the following fixes:

- The Sophos EDR Integration had a disabled unblock function
- The Sophos EDR Integration would send the payload to Sophos Central in the wrong format (json_data instead of json)
- The Hostname validation in the Sophos EDR Integration aswell as the feature to only allow exactly one host would make it so that in a production environment, the function would never run 
- In the config.py file, the lines that define the Brain IPs would make var_config_helper crash due to the config helper assuming a valid line must contain a = sign

Please test and merge these changes at your earliest convinience as the current production version of VAR is not functional in this state.