### PR TITLE
Feature: Remote disabling of NICs for Windows Machines via WinRM plus additional Sophos EDR fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Currently, the following third party integrations are implemented:
 ### System Calls
   1. Call an external program/script
   1. Windows Shutdown (PowerShell command to shutdown host)
+  1. Windows Kill Network Interface (PowerShell command to disable all NICs on a remote Windows host)
   1. VMWare vSphere/ESXi
   1. Static destination IP blocking
 

--- a/config.py
+++ b/config.py
@@ -3,9 +3,9 @@
 COGNITO_URL = ['']
 SLEEP_MINUTES = 5
 # Available options: ['bitdefender', 'checkpoint', 'cisco_amp', 'cisco_asa_http', 'cisco_fmc', 'cisco_ise',
-# 'cisco_pxgrid', 'clearpass', 'cortex', 'endgame', 'external_call', 'forti_edr', q'fortinet',
+# 'cisco_pxgrid', 'clearpass', 'cortex', 'endgame', 'external_call', 'forti_edr', 'fortinet',
 # 'harmony', 'mcafee_epo', 'meraki', 'pan', 'pulse_nac', 'sophos', 'tanium', 'test_client', 'trendmicro_apexone',
-# 'trendmicro_cloudone', 'trendmicro_visionone', 'vmware', 'watchguard', 'windows_shutdown', 'withsecure_elements',
+# 'trendmicro_cloudone', 'trendmicro_visionone', 'vmware', 'watchguard', 'windows_killnic', 'windows_shutdown', 'withsecure_elements',
 # 'xtreme_networks_nbi']
 THIRD_PARTY_CLIENTS = ["test_client"]
 

--- a/third_party_clients/sophos_edr/sophos_edr.py
+++ b/third_party_clients/sophos_edr/sophos_edr.py
@@ -123,7 +123,7 @@ class Client(ThirdPartyInterface):
                 return endpoint
 
     def block_host(self, host: VectraHost) -> list:
-      isolate_url = f"{self.dataRegion}/endpoint/v1/endpoints/isolation"
+        isolate_url = f"{self.dataRegion}/endpoint/v1/endpoints/isolation"
         endpoint = self._list_endpoint(host)
         log_string = f"{host.name} with id {endpoint['id']} and IP {host.ip}"
         if not endpoint:

--- a/third_party_clients/windows_killnic/README.md
+++ b/third_party_clients/windows_killnic/README.md
@@ -1,0 +1,22 @@
+# Windows Shutdown Client
+This client is used to disable all NICs via WinRM on a remote Windows Host.
+
+# Requirements
+- Must be ran from a Windows machine.
+- This client uses a Powershell Scriptlet and WinRM to disable all NICs on a remote windows Host. So `pywinrm` is required.
+
+# Configuration
+- You may configure the `SERVICE_NAME` under which your credentials are stored in the keyring in [windows_killnic_config.py](./windows_killnic_config.py).
+
+# Authentication
+- This client requires that the associated account has administrative privileges.
+
+# Enablement
+To utilize this client within the VAR Framework, add `"windows_killnic"` to the list of `THIRD_PARTY_CLIENTS` in [config.py](../../config.py).
+
+# Validation
+Unvalidated, validation following.
+
+# Resources
+- https://learn.microsoft.com/de-de/windows/win32/cimwin32prov/win32-networkadapter
+- https://www.telonic.de

--- a/third_party_clients/windows_killnic/requirements.txt
+++ b/third_party_clients/windows_killnic/requirements.txt
@@ -1,0 +1,1 @@
+pywinrm

--- a/third_party_clients/windows_killnic/windows_killnic.py
+++ b/third_party_clients/windows_killnic/windows_killnic.py
@@ -1,0 +1,106 @@
+import logging
+import uuid
+import winrm
+
+from common import _get_password
+from third_party_clients.third_party_interface import (
+    ThirdPartyInterface,
+    VectraAccount,
+    VectraHost,
+    VectraStaticIP,
+)
+
+from third_party_clients.windows_killnic.windows_killnic_config import (
+    PORT,
+    SERVICE_NAME
+)
+
+
+# class TestClient(ThirdPartyInterface):
+class Client(ThirdPartyInterface):
+    def __init__(self, **kwargs):
+        # Instantiate parent class
+        self.name = "Windows Kill Network Interface"
+        self.module = "windows_killnic"
+        self.domain = _get_password(SERVICE_NAME, "domain", modify=kwargs["modify"])
+        self.username = _get_password(SERVICE_NAME, "username", modify=kwargs["modify"])
+        self.password = _get_password(SERVICE_NAME, "password", modify=kwargs["modify"])
+        self.init_log(kwargs)
+        ThirdPartyInterface.__init__(self)
+
+    def init_log(self, kwargs):
+        dict_config = kwargs.get("dict_config", {})
+        dict_config["loggers"].update(
+            {self.name: dict_config["loggers"]["VAR"]})
+        logging.config.dictConfig(dict_config)
+        self.logger = logging.getLogger(self.name)
+
+    def block_host(self, host: VectraHost):
+        winrm_url = f"http://{host.name}:{PORT}/wsman"
+
+        powershell_script = """
+        Get-WmiObject -Class Win32_NetworkAdapter |
+        Where-Object { $_.NetEnabled -eq $true -and $_.PhysicalAdapter -eq $true } |
+        ForEach-Object { $_.Disable() }
+        """
+
+        try:
+            session = winrm.Session(
+                winrm_url,
+                auth=(f'{self.domain}\\{self.username}', self.password),
+                transport='ntlm',
+                server_cert_validation='ignore'
+            )
+
+            result = session.run_ps(powershell_script)
+
+            std_out = result.std_out.decode() if result.std_out else ''
+            std_err = result.std_err.decode() if result.std_err else ''
+
+            self.logger.info(std_out)
+            if std_err:
+                self.logger.error(std_err)
+
+        except Exception as e:
+            self.logger.error(f"An issue ocurred trying to disable NIC of: {host.name}")
+            return []
+        
+        return [host.name]
+
+    def unblock_host(self, host: VectraHost):
+        self.logger.warning("This client cannot restart a NIC automatically")
+        return []
+
+    def groom_host(self, host) -> dict:
+        self.logger.warning("This client does not implement host grooming")
+        return []
+
+    def block_detection(self, detection):
+        # this client only implements Host-based blocking
+        self.logger.warning("This client does not implement detection-based blocking")
+        return []
+
+    def unblock_detection(self, detection):
+        # this client only implements Host-based blocking
+        self.logger.warning("This client only implements Host-based blocking")
+        return []
+
+    def block_account(self, account: VectraAccount) -> list:
+        # this client only implements Host-based blocking
+        self.logger.warning("This client only implements Host-based blocking")
+        return []
+
+    def unblock_account(self, account: VectraAccount) -> list:
+        # this client only implements Host-based blocking
+        self.logger.warning("This client only implements Host-based blocking")
+        return []
+
+    def block_static_dst_ips(self, ips: VectraStaticIP) -> list:
+        # this client only implements Host-based blocking
+        self.logger.warning("This client only implements Host-based blocking")
+        return []
+
+    def unblock_static_dst_ips(self, ips: VectraStaticIP) -> list:
+        # this client only implements Host-based blocking
+        self.logger.warning("This client only implements Host-based blocking")
+        return []

--- a/third_party_clients/windows_killnic/windows_killnic_config.py
+++ b/third_party_clients/windows_killnic/windows_killnic_config.py
@@ -1,0 +1,2 @@
+SERVICE_NAME = "winrm_access"
+PORT = 5985


### PR DESCRIPTION
# Features
In cooperation with a customer we created a new module for Vectra Automated Response which authenticates against an endpoint via WinRM and disables all connected NICs via PowerShell execution.

# Fixes
Fixed an unexpected ident in the Sophos EDR Integration

**This Integration is currently untested but will be rolled out in a couple of days, if bugs occur, a followup PR will be created**